### PR TITLE
Allow lto for ndjson

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,25 +11,26 @@ jobs:
                 command: |
                   apt-get update
                   apt-get install -yq libgdal-dev
+                  rustup toolchain add nightly-2020-09-27
             - checkout
             - run:
                 name: Build
                 command: |
                     rustc --version --verbose
-                    cargo --version --verbose
-                    cargo build
+                    cargo +nightly-2020-09-27 --version --verbose
+                    cargo +nightly-2020-09-27 build
             - run:
                 name: Test
                 command: |
-                    cargo test
+                    cargo +nightly-2020-09-27 test
             - run:
                 name: Check Format 
                 command: |
-                    cargo fmt -- --check
+                    cargo +nightly-2020-09-27 fmt -- --check
             - run:
                 name: Clippy Lint
                 command: |
-                    cargo clippy -- -D clippy::all
+                    cargo +nightly-2020-09-27 clippy -- -D clippy::all
 workflows:
     version: 2
     pr-branch-ci:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["named-profiles"]
+
 [workspace]
 members = [
     "ndjson",
@@ -5,6 +7,7 @@ members = [
     "ndjson-spatial"
 ]
 
-[profile.release]
+[profile.release-ndjson]
+inherits = "release"
 lto = true
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@ This repo contains some Rust cli tools for working with new-line delimited geojs
 
 These tools are currently pre-release. There will be releases with builds for linux and macos.
 
+# Build
+
+This repo requires a nightly compiler before 2020-09-28 exclusive.
+
+To build
+```
+rustup default nightly-2020-09-27
+cargo build --release
+```
+
+for lto (optimizations for code speed and size) on `ndjson`
+
+```
+cd ndjson
+cargo build -Z unstable-options --profile=release-ndjson
+
+ls -lh ../target/release-ndjson/ndjson
+```
+
 ## Current
 
 ## ndjson-spatial

--- a/ndjson-common/Cargo.toml
+++ b/ndjson-common/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Boyd Johnson <johnson.boyd@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-encode_unicode = "^0.3"
-geo = "^0.14"
-geos = { version = "7.0.0", features = ["json"] }
-geojson = { version = "^0.19", features = ["geo-types"] }
-geo-types = "^0.6"
-geojson-rstar = { git = "https://github.com/boydjohnson/geojson-rstar" }
+geo = { version = "^0.14", optional = true }
+geos = { version = "7.0.0", features = ["json"], optional = true }
+geojson = { version = "^0.19", features = ["geo-types"], optional = true }
+geo-types = { version = "^0.6", optional = true }
+geojson-rstar = { git = "https://github.com/boydjohnson/geojson-rstar", optional = true }
 nom = "4.2"
 serde_json = "1.0"
 yajlish = { version = "^0.2", features = ["ndjson"] }
+
+[features]
+spatial = ["geos", "geojson-rstar", "geo-types", "geojson", "geo"]

--- a/ndjson-common/src/error.rs
+++ b/ndjson-common/src/error.rs
@@ -19,6 +19,7 @@ pub enum NdJsonSpatialError {
     Error(String),
 }
 
+#[cfg(feature = "spatial")]
 impl From<geos::Error> for NdJsonSpatialError {
     fn from(other: geos::Error) -> Self {
         NdJsonSpatialError::Error(format!("Geos Error: {}", other))

--- a/ndjson-common/src/lib.rs
+++ b/ndjson-common/src/lib.rs
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#[cfg(feature = "spatial")]
 pub mod common;
 pub mod error;
 pub mod from;

--- a/ndjson-common/src/ndjson.rs
+++ b/ndjson-common/src/ndjson.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::error::NdJsonSpatialError;
+#[cfg(feature = "spatial")]
 use geojson::GeoJson;
 use serde_json::Value;
 use std::io::{stderr, stdin, BufRead, BufReader, Stdin, Write};
@@ -22,10 +23,12 @@ use std::io::{stderr, stdin, BufRead, BufReader, Stdin, Write};
 /// A struct for reading ndjson geojson from a `BufRead` source,
 /// most usually `BufReader<Stdin>` which is provided by `NdjsonGeojsonReader::default()`.
 /// Often used as the `Iterator` impl for which `Self::Item = geojson::GeoJson`.
+#[cfg(feature = "spatial")]
 pub struct NdJsonGeojsonReader<IN> {
     std_in: IN,
 }
 
+#[cfg(feature = "spatial")]
 impl<IN> NdJsonGeojsonReader<IN>
 where
     IN: BufRead,
@@ -35,6 +38,7 @@ where
     }
 }
 
+#[cfg(feature = "spatial")]
 impl<'a> Default for NdJsonGeojsonReader<BufReader<Stdin>> {
     fn default() -> Self {
         let s = stdin();
@@ -42,6 +46,7 @@ impl<'a> Default for NdJsonGeojsonReader<BufReader<Stdin>> {
     }
 }
 
+#[cfg(feature = "spatial")]
 impl<IN> Iterator for NdJsonGeojsonReader<IN>
 where
     IN: BufRead,

--- a/ndjson-spatial/Cargo.toml
+++ b/ndjson-spatial/Cargo.toml
@@ -16,6 +16,6 @@ geos = { version = "7.0.0", features = ["json", "geo"] }
 geo-types = "^0.6"
 geojson = { version = "^0.19", features = ["geo-types"] }
 geojson-rstar = { git = "https://github.com/boydjohnson/geojson-rstar" }
-ndjson-common = { path = "../ndjson-common" }
+ndjson-common = { path = "../ndjson-common", features = ["spatial"] }
 rstar = "^0.8"
 serde_json = "^1.0"

--- a/ndjson/src/ndjson_main.rs
+++ b/ndjson/src/ndjson_main.rs
@@ -14,6 +14,8 @@
 * limitations under the License.
 */
 
+#![feature(move_ref_pattern)]
+
 use clap::{App, Arg, ArgMatches, SubCommand};
 use ndjson_common::json_selector_parser::{parse_json_selector, Selector};
 use std::{


### PR DESCRIPTION
This allows for `cd ndjson && cargo build -Z unstable-options --profile=release-ndjson`.

`cargo build --release` works too, but you don't get lto on ndjson.